### PR TITLE
Use nodesource's debs for the latest stable node. Install latest stable npm.

### DIFF
--- a/images/js-onbuild/Dockerfile
+++ b/images/js-onbuild/Dockerfile
@@ -2,36 +2,10 @@ FROM markadams/chromium-xvfb
 
 RUN apt-get update && apt-get install -y curl
 
-# -- BEGIN BORROWED FROM docker-node/blob/master/4.0/Dockerfile
+RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
+RUN apt-get install -y nodejs
 
-# gpg keys listed at https://github.com/nodejs/node
-RUN set -ex \
-  && for key in \
-    9554F04D7259F04124DE6B476D5A82AC7E37093B \
-    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-  ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-  done
-
-ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 4.1.0
-
-RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
-  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-  && gpg --verify SHASUMS256.txt.asc \
-  && grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
-  && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
-  && rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
-
-# -- END BORROWED FROM docker-node/blob/master/4.0/Dockerfile
-
-RUN npm install -g npm@3.3.3
-
-WORKDIR /usr/src/app
+RUN npm install -g npm@latest
 
 CMD npm test
 

--- a/images/js/Dockerfile
+++ b/images/js/Dockerfile
@@ -2,34 +2,10 @@ FROM markadams/chromium-xvfb
 
 RUN apt-get update && apt-get install -y curl
 
-# -- BEGIN BORROWED FROM docker-node/blob/master/4.0/Dockerfile
+RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
+RUN apt-get install -y nodejs
 
-# gpg keys listed at https://github.com/nodejs/node
-RUN set -ex \
-  && for key in \
-    9554F04D7259F04124DE6B476D5A82AC7E37093B \
-    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-  ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-  done
-
-ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 4.1.0
-
-RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
-  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-  && gpg --verify SHASUMS256.txt.asc \
-  && grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
-  && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
-  && rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
-
-# -- END BORROWED FROM docker-node/blob/master/4.0/Dockerfile
-
-RUN npm install -g npm@3.3.3
+RUN npm install -g npm@latest
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
This will always install the latest stable node in the 4.x series (so no breaking changes) through [nodesource's debs](https://github.com/nodesource/distributions). It will always install the latest stable npm.

Ideally there are no hardcoded references to the node binary in any downstream images as the debs install themselves into `/usr/bin` instead of `/usr/local/bin`.