### PR TITLE
fixed issue 8 by setting workdir and adding dependency

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -5,4 +5,3 @@ RUN apt-get update && apt-get install -y xvfb chromium
 ADD xvfb-chromium /usr/bin/xvfb-chromium
 RUN ln -s /usr/bin/xvfb-chromium /usr/bin/google-chrome
 RUN ln -s /usr/bin/xvfb-chromium /usr/bin/chromium-browser
-WORKDIR /app

--- a/images/js-onbuild/Dockerfile
+++ b/images/js-onbuild/Dockerfile
@@ -1,5 +1,7 @@
 FROM markadams/chromium-xvfb
 
+WORKDIR /usr/src/app
+
 RUN apt-get update && apt-get install -y curl
 
 RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -

--- a/samples/js/package.json
+++ b/samples/js/package.json
@@ -15,7 +15,8 @@
     "karma": "^0.12.31",
     "karma-chrome-launcher": "^0.1.7",
     "karma-junit-reporter": "^0.2.2",
-    "karma-qunit": "^0.1.4"
+    "karma-qunit": "^0.1.4",
+    "qunitjs": "^1.14.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Issue #8 seemed to be caused by the base image `WORKDIR` instruction being set to `/app`. Also found that with NPMv3, the qunit dependency wasn't installing which is why it's been added as a dependency in package.json 

Setup a clone image with the fix for the time being [here on Docker Hub](https://hub.docker.com/r/davidwesst/docker-chromium-xvfb/).