### PR TITLE
Include git with -js image. fixes #16

### DIFF
--- a/images/js/Dockerfile
+++ b/images/js/Dockerfile
@@ -3,7 +3,7 @@ FROM markadams/chromium-xvfb
 RUN apt-get update && apt-get install -y curl
 
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
-RUN apt-get install -y nodejs && npm install -g npm@latest
+RUN apt-get install -y nodejs git && npm install -g npm@latest
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Some npm packages rely on git operations during build. As this is a _very_ common workflow it makes sense to add this to the base image.

I've tested this change and verified it works for me ;-)