### PR TITLE
Add support for node 8.x; remove 7.x

### DIFF
--- a/images/js-onbuild/Dockerfile-8.x
+++ b/images/js-onbuild/Dockerfile-8.x
@@ -1,9 +1,9 @@
 FROM markadams/chromium-xvfb
 
 WORKDIR /usr/src/app
-ENV NODE_VERSION=7.10.1-2
+ENV NODE_VERSION=8.4.0-1
 
-RUN curl -sL https://deb.nodesource.com/setup_7.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - \
     && apt-get install -y nodejs=${NODE_VERSION}nodesource1~jessie1 \
     && rm -rf /var/lib/apt/lists
 

--- a/images/js/Dockerfile-8.x
+++ b/images/js/Dockerfile-8.x
@@ -1,9 +1,9 @@
 FROM markadams/chromium-xvfb
 
 WORKDIR /usr/src/app
-ENV NODE_VERSION=7.10.1-2
+ENV NODE_VERSION=8.4.0-1
 
-RUN curl -sL https://deb.nodesource.com/setup_7.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - \
     && apt-get install -y nodejs=${NODE_VERSION}nodesource1~jessie1 \
     && rm -rf /var/lib/apt/lists
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -18,8 +18,8 @@ docker build -f samples/python3/Dockerfile -t markadams/chromium-xvfb-py3-sample
 docker build -f images/js/Dockerfile-6.x -t markadams/chromium-xvfb-js:6 images/js
 docker build -f images/js-onbuild/Dockerfile-6.x -t markadams/chromium-xvfb-js:6-onbuild images/js-onbuild
 
-docker build -f images/js/Dockerfile-7.x -t markadams/chromium-xvfb-js:7 images/js
-docker build -f images/js-onbuild/Dockerfile-7.x -t markadams/chromium-xvfb-js:7-onbuild images/js-onbuild
+docker build -f images/js/Dockerfile-8.x -t markadams/chromium-xvfb-js:8 images/js
+docker build -f images/js-onbuild/Dockerfile-8.x -t markadams/chromium-xvfb-js:8-onbuild images/js-onbuild
 
 docker build -f samples/js/Dockerfile -t markadams/chromium-xvfb-js-sample samples/js
 

--- a/samples/js/Dockerfile
+++ b/samples/js/Dockerfile
@@ -1,4 +1,4 @@
-FROM markadams/chromium-xvfb-js:7
+FROM markadams/chromium-xvfb-js:8
 
 COPY package.json /usr/src/app/package.json
 COPY package-lock.json /usr/src/app/package-lock.json


### PR DESCRIPTION
Node 8.x is the current supported non-LTS release of node and should be
supported. Node 7.x is no longer supported and should no longer be
built.