### PR TITLE
Update Chromedriver to 2.29 for Python images

### DIFF
--- a/images/python2-onbuild/Dockerfile
+++ b/images/python2-onbuild/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update && apt-get install -y \
 
 RUN pip install pytest selenium
 
-ENV CHROMEDRIVER_VERSION 2.28
-ENV CHROMEDRIVER_SHA256 8f5b0ab727c326a2f7887f08e4f577cb4452a9e5783d1938728946a8557a37bc
+ENV CHROMEDRIVER_VERSION 2.29
+ENV CHROMEDRIVER_SHA256 bb2cf08f2c213f061d6fbca9658fc44a367c1ba7e40b3ee1e3ae437be0f901c2
 
 RUN curl -SLO "https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" \
   && echo "$CHROMEDRIVER_SHA256  chromedriver_linux64.zip" | sha256sum -c - \

--- a/images/python2/Dockerfile
+++ b/images/python2/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update && apt-get install -y \
 
 RUN pip install pytest selenium
 
-ENV CHROMEDRIVER_VERSION 2.28
-ENV CHROMEDRIVER_SHA256 8f5b0ab727c326a2f7887f08e4f577cb4452a9e5783d1938728946a8557a37bc
+ENV CHROMEDRIVER_VERSION 2.29
+ENV CHROMEDRIVER_SHA256 bb2cf08f2c213f061d6fbca9658fc44a367c1ba7e40b3ee1e3ae437be0f901c2
 
 RUN curl -SLO "https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" \
   && echo "$CHROMEDRIVER_SHA256  chromedriver_linux64.zip" | sha256sum -c - \

--- a/images/python3-onbuild/Dockerfile
+++ b/images/python3-onbuild/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update && apt-get install -y \
 
 RUN pip3 install pytest selenium
 
-ENV CHROMEDRIVER_VERSION 2.28
-ENV CHROMEDRIVER_SHA256 8f5b0ab727c326a2f7887f08e4f577cb4452a9e5783d1938728946a8557a37bc
+ENV CHROMEDRIVER_VERSION 2.29
+ENV CHROMEDRIVER_SHA256 bb2cf08f2c213f061d6fbca9658fc44a367c1ba7e40b3ee1e3ae437be0f901c2
 
 RUN curl -SLO "https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" \
   && echo "$CHROMEDRIVER_SHA256  chromedriver_linux64.zip" | sha256sum -c - \

--- a/images/python3/Dockerfile
+++ b/images/python3/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update && apt-get install -y \
 
 RUN pip3 install pytest selenium
 
-ENV CHROMEDRIVER_VERSION 2.28
-ENV CHROMEDRIVER_SHA256 8f5b0ab727c326a2f7887f08e4f577cb4452a9e5783d1938728946a8557a37bc
+ENV CHROMEDRIVER_VERSION 2.29
+ENV CHROMEDRIVER_SHA256 bb2cf08f2c213f061d6fbca9658fc44a367c1ba7e40b3ee1e3ae437be0f901c2
 
 RUN curl -SLO "https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" \
   && echo "$CHROMEDRIVER_SHA256  chromedriver_linux64.zip" | sha256sum -c - \


### PR DESCRIPTION
Update Chromedriver to 2.29 for Python images:

Changes include:
Fixes a bug which caused ExecuteScript to fail when Object.prototype is modified.
Fixes a bug that interferes with handling the alert dialog on page unload.
Support for making the window tab visible on switching to windows.