### PR TITLE
set default encoding to UTF-8

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:jessie
 
+ENV LANG C.UTF-8
+
 RUN apt-get update && apt-get install -y curl xvfb chromium
 
 ADD xvfb-chromium /usr/bin/xvfb-chromium


### PR DESCRIPTION
It fixes problems like this one https://github.com/gopaycommunity/gopay-python-api/issues/6 I stumbled upon in automatized tests