### PR TITLE
Update base Dockerfiles to rebuild

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:stable
 
 RUN apt-get update && apt-get install -y curl xvfb chromium
+COPY pin_nodesource /etc/apt/preferences.d/nodesource
 
 ADD xvfb-chromium /usr/bin/xvfb-chromium
 RUN ln -s /usr/bin/xvfb-chromium /usr/bin/google-chrome

--- a/images/base/pin_nodesource
+++ b/images/base/pin_nodesource
@@ -1,0 +1,3 @@
+Package: *
+Pin: origin deb.nodesource.com
+Pin-Priority: 600

--- a/images/js-onbuild/Dockerfile-8.x
+++ b/images/js-onbuild/Dockerfile-8.x
@@ -1,11 +1,10 @@
 FROM markadams/chromium-xvfb
 
 WORKDIR /usr/src/app
-ENV NODE_VERSION=8.10.0-1
 
 RUN apt-get install -y gpg \
     && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
-    && apt-get install -y nodejs=${NODE_VERSION}nodesource1 \
+    && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists
 
 CMD npm test

--- a/images/js-onbuild/Dockerfile-9.x
+++ b/images/js-onbuild/Dockerfile-9.x
@@ -1,11 +1,10 @@
 FROM markadams/chromium-xvfb
 
 WORKDIR /usr/src/app
-ENV NODE_VERSION=9.8.0-1
 
 RUN apt-get install -y gpg \
     && curl -sL https://deb.nodesource.com/setup_9.x | bash - \
-    && apt-get install -y nodejs=${NODE_VERSION}nodesource1 gpg \
+    && apt-get install -y nodejs gpg \
     && rm -rf /var/lib/apt/lists
 
 CMD npm test

--- a/images/js/Dockerfile-8.x
+++ b/images/js/Dockerfile-8.x
@@ -1,11 +1,10 @@
 FROM markadams/chromium-xvfb
 
 WORKDIR /usr/src/app
-ENV NODE_VERSION=8.10.0-1
 
 RUN apt-get install -y gpg \
     && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
-    && apt-get install -y nodejs=${NODE_VERSION}nodesource1 gpg \
+    && apt-get install -y nodejs gpg \
     && rm -rf /var/lib/apt/lists
 
 CMD npm test

--- a/images/js/Dockerfile-9.x
+++ b/images/js/Dockerfile-9.x
@@ -1,11 +1,10 @@
 FROM markadams/chromium-xvfb
 
 WORKDIR /usr/src/app
-ENV NODE_VERSION=9.8.0-1
 
 RUN apt-get install -y gpg \
     && curl -sL https://deb.nodesource.com/setup_9.x | bash - \
-    && apt-get install -y nodejs=${NODE_VERSION}nodesource1 gpg \
+    && apt-get install -y nodejs gpg \
     && rm -rf /var/lib/apt/lists
 
 CMD npm test


### PR DESCRIPTION
The base images were out of date and causing this error:

```
Step 4/30 : RUN apt-get update && apt-get install -y git tar bzip2 ack-grep libelf1 curl git gpg python
 ---> Running in f32a23ce1741
Get:1 http://deb.debian.org/debian stable InRelease [118 kB]
Get:2 http://deb.debian.org/debian stable-updates InRelease [49.3 kB]
Get:3 http://security.debian.org stable/updates InRelease [39.1 kB]
Get:4 http://deb.debian.org/debian stable/main amd64 Packages [10.6 MB]
Get:5 http://security.debian.org stable/updates/main amd64 Packages [72.6 kB]
Get:6 http://deb.debian.org/debian stable-updates/main amd64 Packages.diff/Index [736 B]
Get:6 http://deb.debian.org/debian stable-updates/main amd64 Packages.diff/Index [736 B]
Get:7 http://deb.debian.org/debian stable-updates/main amd64 Packages [809 B]
Reading package lists...
W: Conflicting distribution: http://deb.debian.org/debian stable InRelease (expected stretch but got buster)
W: Conflicting distribution: http://deb.debian.org/debian stable-updates InRelease (expected stretch-updates but got buster-updates)
W: Conflicting distribution: http://security.debian.org stable/updates InRelease (expected stretch but got buster)
E: Could not open file /var/lib/apt/lists/deb.debian.org_debian_dists_stable-updates_main_binary-amd64_Packages.diff_Index - open (2: No such file or directory)
```

I tried to just run `./run_tests.sh` to get it to rebuild with a more recent version of  `debian:stable`, but then ran into this issue

```
E: Version '8.16.0nodesource' for 'nodejs' was not found
```

This was because specifying this kind of version for source no longer works. Instead, @mafrauen showed me what we're doing in another Docker base and I copied that into this repo and add the pinning at the root. This way, if you specify a source, it just works for all the builds.